### PR TITLE
make executeAutomatically a bool

### DIFF
--- a/src/features/accounts/api/create-account.ts
+++ b/src/features/accounts/api/create-account.ts
@@ -22,7 +22,7 @@ export function useCreateAccount() {
   const [, n] = useNetworkContext()
   return useMutation<CreateAccountResponse, Error, CreateAccountFormData>(
     async (vars: CreateAccountFormData) => {
-      const accountName = vars.accountSettings.name
+      const name = vars.accountSettings.name
       const roles = vars.accountSettings.owners.reduce(
         (
           acc: Map<string, string[]>,
@@ -34,7 +34,7 @@ export function useCreateAccount() {
         new Map(),
       )
       const features = makeFeatures(vars.features, vars.featureSettings)
-      const res = await n?.account.create(accountName, roles, features)
+      const res = await n?.account.create({ name, roles, features })
       return res
     },
   )
@@ -56,7 +56,7 @@ function makeFeatures(
       multisigSettings as {
         threshold: number
         expireInSecs: number
-        executeAutomatically: "0" | "1"
+        executeAutomatically: boolean
       }
     const multisigArguments = [
       AccountFeatureTypes.accountMultisig,
@@ -65,7 +65,7 @@ function makeFeatures(
         .set(AccountMultisigArgument.expireInSecs, expireInSecs)
         .set(
           AccountMultisigArgument.executeAutomatically,
-          executeAutomatically === "1",
+          executeAutomatically,
         ),
     ]
     result.push(multisigArguments)

--- a/src/features/accounts/components/account-selector/create-account/create-account.tsx
+++ b/src/features/accounts/components/account-selector/create-account/create-account.tsx
@@ -82,7 +82,7 @@ export function CreateAccount() {
           hours: 0,
           minutes: 0,
           seconds: 0,
-          executeAutomatically: "0",
+          executeAutomatically: false,
         },
       },
     },
@@ -606,7 +606,7 @@ function Review() {
             label="Execute Automatically"
             value={
               values.featureSettings[accountMultisigFeature]
-                .executeAutomatically === "1"
+                .executeAutomatically
                 ? "Yes"
                 : "No"
             }

--- a/src/features/accounts/components/multisig-settings-fields/multisig-settings-fields.tsx
+++ b/src/features/accounts/components/multisig-settings-fields/multisig-settings-fields.tsx
@@ -44,7 +44,6 @@ export function MultisigSettingsFields({
 
   const { field: radioField } = useController({
     name: executeAutomaticallyFieldName,
-    rules: { required: "This field is required" },
   })
 
   const { data: accountInfoData } = useGetAccountInfo(accountAddress)
@@ -90,10 +89,7 @@ export function MultisigSettingsFields({
         const currExecuteAutomatically = multisigFeature.get(
           AccountMultisigArgument[AccountMultisigArgument.executeAutomatically],
         )
-        setValue(
-          executeAutomaticallyFieldName,
-          currExecuteAutomatically === true ? "1" : "0",
-        )
+        setValue(executeAutomaticallyFieldName, currExecuteAutomatically)
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -212,7 +208,14 @@ export function MultisigSettingsFields({
         description="Execute transactions automatically when threshold has been reached."
         error={get(errors, executeAutomaticallyFieldName)?.message}
       >
-        <RadioGroup colorScheme="brand.teal" {...radioField}>
+        <RadioGroup
+          colorScheme="brand.teal"
+          {...radioField}
+          value={radioField.value === false ? "0" : "1"}
+          onChange={val => {
+            radioField.onChange(val === "1")
+          }}
+        >
           <HStack spacing={4}>
             <Radio value="0" isReadOnly={!canEdit}>
               No

--- a/src/features/transactions/components/send-asset/send-asset.tsx
+++ b/src/features/transactions/components/send-asset/send-asset.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useForm, FormProvider } from "react-hook-form"
-import { AccountMultisigArgument, ANON_IDENTITY } from "many-js"
+import { ANON_IDENTITY } from "many-js"
 import {
   AddressText,
   Alert,
@@ -131,7 +131,7 @@ export function useSendAssetForm({
       hours: 0,
       minutes: 0,
       seconds: 0,
-      executeAutomatically: "0",
+      executeAutomatically: false,
     },
   }
 
@@ -188,28 +188,12 @@ export function useSendAssetForm({
   ): { [k: string]: unknown } {
     const result: { [k: string]: unknown } = {}
     if (oldSettings && newSettings) {
-      if (
-        oldSettings?.get(
-          AccountMultisigArgument[AccountMultisigArgument.threshold],
-        ) !== newSettings.threshold
-      ) {
-        result.threshold = newSettings.threshold
-      }
-      if (
-        oldSettings?.get(
-          AccountMultisigArgument[AccountMultisigArgument.expireInSecs],
-        ) !== newSettings.expireInSecs
-      ) {
-        result.expireInSecs = newSettings.expireInSecs
-      }
-      const newExecuteAutomatically = newSettings.executeAutomatically === "1"
-      if (
-        oldSettings?.get(
-          AccountMultisigArgument[AccountMultisigArgument.executeAutomatically],
-        ) !== newExecuteAutomatically
-      ) {
-        result.executeAutomatically = newExecuteAutomatically
-      }
+      Object.keys(newSettings).forEach(k => {
+        const newValue = newSettings[k]
+        if (oldSettings?.has(k) && oldSettings?.get(k) !== newValue) {
+          result[k] = newValue
+        }
+      })
     }
 
     return result
@@ -558,7 +542,7 @@ export function SendAssetForm({
         expireHours={hours}
         expireMinutes={minutes}
         expireSeconds={seconds}
-        executeAutomatically={executeAutomatically === "1"}
+        executeAutomatically={executeAutomatically}
         threshold={threshold}
         showMultisigSettings={showMultisigSettings}
       />

--- a/src/features/transactions/components/txn-list/txn-list-item/multisig-txn-list-item.tsx
+++ b/src/features/transactions/components/txn-list/txn-list-item/multisig-txn-list-item.tsx
@@ -120,7 +120,7 @@ function MultisigSetDefaultsTxnDetailsModal({
         </DataField>
         <DataField
           label="Execute Automatically"
-          value={multisigTxn.executeAutomatically === true ? "Yes" : "No"}
+          value={multisigTxn.executeAutomatically ? "Yes" : "No"}
         />
       </Modal.Body>
     </Modal>
@@ -370,7 +370,7 @@ function MultisigTxnDetailsModal({
 
         <DataField
           label="Execute Automatically"
-          value={executeAutomatically === true ? "Yes" : "No"}
+          value={executeAutomatically ? "Yes" : "No"}
         />
       </Modal.Body>
     </Modal>

--- a/src/views/accounts/multisig-settings/multisig-settings.tsx
+++ b/src/views/accounts/multisig-settings/multisig-settings.tsx
@@ -17,7 +17,7 @@ export function MultisigSettings({
       hours: 0,
       minutes: 0,
       seconds: 0,
-      executeAutomatically: "0",
+      executeAutomatically: false,
     },
   })
 
@@ -35,12 +35,12 @@ export function MultisigSettings({
   }: {
     expireInSecs: number
     threshold: number
-    executeAutomatically: string
+    executeAutomatically: boolean
   }) {
     doSetMultisigDefaults({
       expireInSecs,
       threshold,
-      executeAutomatically: executeAutomatically === "1",
+      executeAutomatically,
     })
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

- makes executeAutomatically a bool instead of string
- fix `accunt.createAccount` call to match signature from many-js

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->
