### PR TITLE
send asset next btn disabled until all fields filled

### DIFF
--- a/src/features/transactions/components/send-asset/send-asset.tsx
+++ b/src/features/transactions/components/send-asset/send-asset.tsx
@@ -76,8 +76,7 @@ export function SendAssetModal({
           <Button
             width={{ base: "full", md: "auto" }}
             colorScheme="brand.teal"
-            type="submit"
-            form="send-asset-form"
+            disabled={sendAssetState.isNextDisabled}
             onClick={sendAssetState.formMethods.handleSubmit(
               sendAssetState.onNext,
             )}
@@ -246,9 +245,12 @@ export function useSendAssetForm({
     return
   }
 
+  const [watchTo, watchAmount] = formMethods.watch(["to", "amount"])
+
   return {
     balances,
     onNext,
+    isNextDisabled: !watchTo || !watchAmount || !asset,
     onSendTxn,
     doCreateMultisigSubmitTxn,
     error: createMultisigSubmitTxnError?.message || createSendTxnError?.message,
@@ -269,13 +271,11 @@ export function useSendAssetForm({
 
 export function SendAssetForm({
   accountAddress,
-  formId = "send-asset-form",
   sendAssetState,
   showNextBtn = true,
 }: {
   accountAddress?: string
   sendAssetState: ReturnType<typeof useSendAssetForm>
-  formId?: string
   onSuccess?: () => void
   showNextBtn?: boolean
 }) {
@@ -283,6 +283,7 @@ export function SendAssetForm({
   const {
     balances,
     onNext,
+    isNextDisabled,
     onSendTxn,
     isCreateMultisigSubmitTxnLoading,
     isCreateSendTxnLoading,
@@ -302,7 +303,6 @@ export function SendAssetForm({
     formState: { errors },
   } = formMethods
 
-  const watchTo = formMethods.watch("to")
   const {
     to,
     amount,
@@ -315,15 +315,12 @@ export function SendAssetForm({
       threshold,
     },
   } = formMethods.getValues()
-  const contactName = getContactName(watchTo)
+
+  const contactName = getContactName(to)
 
   return (
     <FormProvider {...formMethods}>
-      <form
-        onSubmit={formMethods.handleSubmit(onNext)}
-        aria-label="send form"
-        id={formId}
-      >
+      <div aria-label="send form">
         <VStack alignItems="flex-start" spacing={5}>
           <FieldWrapper
             isRequired
@@ -519,15 +516,16 @@ export function SendAssetForm({
             <Flex justifyContent="flex-end" w="full">
               <Button
                 width={{ base: "full", md: "auto" }}
+                disabled={isNextDisabled}
                 colorScheme="brand.teal"
-                type="submit"
+                onClick={formMethods.handleSubmit(onNext)}
               >
                 Next
               </Button>
             </Flex>
           )}
         </VStack>
-      </form>
+      </div>
       <ConfirmTxnDialog
         isOpen={isShowConfirmDialog}
         onClose={onCloseConfirmDialog}

--- a/src/views/home/symbols/symbols.tsx
+++ b/src/views/home/symbols/symbols.tsx
@@ -93,6 +93,7 @@ export function Symbols({
       </Stack>
       {isSendAssetModalOpen && (
         <SendAssetModal
+          key={String(isSendAssetModalOpen)}
           isOpen={isSendAssetModalOpen}
           onClose={onClose}
           address={address}


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->

- disables the next button in the send flow until "to", "amount", and "asset" is filled in.

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes https://github.com/liftedinit/albert/issues/73

## Screenshots (if applicable)

https://user-images.githubusercontent.com/7282254/185984272-5b9d2b46-e4f8-4ed8-95eb-7292e5d72c93.mov


