### PR TITLE
beginning and end characters of address text should be visible

### DIFF
--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,1 +1,2 @@
 export * from "./field-wrapper"
+export * from "./validations"

--- a/src/components/form/validations/index.ts
+++ b/src/components/form/validations/index.ts
@@ -1,0 +1,7 @@
+export const validateAddress = (val: string) => {
+  console.log({ formatVal: val })
+  return (
+    (/^m[0-9a-z]*$/.test(val) && val.length === 50) ||
+    "Address should start with m and be 50 characters long"
+  )
+}

--- a/src/components/form/validations/index.ts
+++ b/src/components/form/validations/index.ts
@@ -1,6 +1,8 @@
-export const validateAddress = (val: string) => {
+export const validateAddressMessage =
+  "Address should start with m and have a minimum of 50 characters"
+
+export function validateAddress(val: string): true | string {
   return (
-    (/^m[0-9a-z]*$/.test(val) && val.length >= 50) ||
-    "Address should start with m and have a minimum of 50 characters"
+    (/^m[0-9a-z]*$/.test(val) && val.length >= 50) || validateAddressMessage
   )
 }

--- a/src/components/form/validations/index.ts
+++ b/src/components/form/validations/index.ts
@@ -1,7 +1,6 @@
 export const validateAddress = (val: string) => {
-  console.log({ formatVal: val })
   return (
-    (/^m[0-9a-z]*$/.test(val) && val.length === 50) ||
-    "Address should start with m and be 50 characters long"
+    (/^m[0-9a-z]*$/.test(val) && val.length >= 50) ||
+    "Address should start with m and have a minimum of 50 characters"
   )
 }

--- a/src/features/contacts/components/contacts-management/contacts-management.tsx
+++ b/src/features/contacts/components/contacts-management/contacts-management.tsx
@@ -4,9 +4,11 @@ import {
   Button,
   Center,
   HStack,
+  IconButton,
   Input,
   InputGroup,
   InputLeftElement,
+  PlusIcon,
   SearchIcon,
   Text,
   VStack,
@@ -59,7 +61,15 @@ export function ContactsManagement({
             </InputGroup>
             <UpdateContact header="Create Contact">
               {onOpen => {
-                return <Button onClick={onOpen}>Add</Button>
+                return (
+                  <IconButton
+                    rounded="full"
+                    size="sm"
+                    aria-label="import account"
+                    icon={<PlusIcon boxSize={6} />}
+                    onClick={onOpen}
+                  />
+                )
               }}
             </UpdateContact>
           </HStack>


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->
- address feedback from https://liftedinit.slack.com/archives/C02EFTD4HQ9/p1662069162703239
- shortens the address text so that the first and last characters are visible

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes https://github.com/liftedinit/albert/issues/80

## Testing

<!-- Please describe how you tested your changes. -->
<!-- Include details of your testing environment and the tests you ran. -->
- adds jest tests


## Screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/7282254/189802717-cf49e364-acf9-4ada-bdb7-4e87907a84d5.png)

After:
![image](https://user-images.githubusercontent.com/7282254/189802787-760bea42-0f73-499d-b5f5-8a56093a4f92.png)


