### PR TITLE
fix arg to fromHex to generate identity

### DIFF
--- a/src/features/accounts/components/social-login/social-login.tsx
+++ b/src/features/accounts/components/social-login/social-login.tsx
@@ -77,7 +77,9 @@ export function SocialLogin({ onSuccess }: { onSuccess: () => void }) {
         isEmailPasswordless,
       })
 
-      const identity = Ed25519KeyPairIdentity.fromHex(privateKey.slice(0, 32))
+      const identity = Ed25519KeyPairIdentity.fromHex(
+        Buffer.from(privateKey, "hex"),
+      )
       const address = (await identity.getAddress()).toString()
 
       const accountExists = await doesAccountExist(address, accounts)


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->

- convert hex to buffer before passing it into `fromHex` is the correct way