### PR TITLE
Use base64url encoding for Transaction IDs in URIs

### DIFF
--- a/src/features/transactions/components/txn-list/txn-list-item/multisig-txn-list-item.tsx
+++ b/src/features/transactions/components/txn-list/txn-list-item/multisig-txn-list-item.tsx
@@ -42,7 +42,7 @@ import { useMultisigActions, useMultisigTxn, useSendTxn } from "./hooks"
 import { BaseTxnListItem } from "./base-txn-list-item"
 import { BaseTxnDetails } from "./base-txn-details"
 import {
-  arrayBufferToBase64,
+  arrayBufferToBase64Url,
   getHoursMinutesSecondsFromSeconds,
 } from "helper/convert"
 
@@ -190,7 +190,7 @@ export function SubmittedMultisigTxnDetails({
 }) {
   const { token, time, id, account } = multisigTxn
 
-  const base64TxnId = id ? encodeURIComponent(arrayBufferToBase64(id)) : null
+  const base64TxnId = id ? encodeURIComponent(arrayBufferToBase64Url(id)) : null
 
   const getContactName = useGetContactName()
 

--- a/src/helper/__tests__/convert.test.ts
+++ b/src/helper/__tests__/convert.test.ts
@@ -1,0 +1,44 @@
+import {base64UrlToArrayBuffer, arrayBufferToBase64Url} from "../convert"
+
+function testCodecRoundTrip<
+    T extends BufferSource,
+    E = string
+>(
+    encoder: (arg: T) => E,
+    decoder: (arg: E) => T,
+) {
+  for (let i = 0; i < 100; i++) {
+    // Generate a random [50, 100[ buffer.
+    let buffer = new Uint8Array(Math.floor(Math.random() * 50 + 50))
+    for (let j = 0; j < buffer.byteLength; j++) {
+      buffer[j] = Math.random() * 256
+    }
+
+    let encoded: E = encoder(buffer.buffer as T)
+    let decoded: T = decoder(encoded)
+
+    expect(Buffer.from(decoded)).toEqual(Buffer.from(buffer))
+  }
+}
+
+describe("base64url", () => {
+  it("should work with round-trip random data", () => {
+    testCodecRoundTrip(arrayBufferToBase64Url, base64UrlToArrayBuffer)
+  })
+
+  it("should work with golden values", () => {
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQ")))
+        .toBe("Hello World")
+
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQgMQ")))
+        .toBe("Hello World 1")
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQgMTI")))
+        .toBe("Hello World 12")
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQgMTIz")))
+        .toBe("Hello World 123")
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQgMTIzNA")))
+        .toBe("Hello World 1234")
+    expect(new TextDecoder().decode(base64UrlToArrayBuffer("SGVsbG8gV29ybGQgMTIzNDU")))
+        .toBe("Hello World 12345")
+  })
+})

--- a/src/helper/convert.ts
+++ b/src/helper/convert.ts
@@ -12,6 +12,19 @@ export const base64ToArrayBuffer = (str: string): ArrayBuffer =>
 export const arrayBufferToBase64 = (buffer: ArrayBuffer): string =>
   Buffer.from(buffer).toString("base64")
 
+export const base64UrlToArrayBuffer = (str: string): ArrayBuffer =>
+    // Add back the `===` that were missing. These are between 0 and 3,
+    // depending on if there are any remainder to the base64 string.
+    // Base64 are always multiples of 4.
+    base64ToArrayBuffer(str + "===".slice(0, str.length % 4))
+
+export const arrayBufferToBase64Url = (buffer: ArrayBuffer): string =>
+    // Remove the === at the end to make it base64url.
+    // `base64url` encoding is supported by Node but not the version of `buffer`
+    // we actually install and use.
+    arrayBufferToBase64(buffer).replace(/=+$/, "")
+
+
 export const fromDateTime = (date: Date) => {
   const rft = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
 
@@ -22,7 +35,7 @@ export const fromDateTime = (date: Date) => {
   const WEEK = 7 * DAY;
   const MONTH = 30 * DAY;
   const YEAR = 365 * DAY;
-  
+
   const intervals = [
       { ge: YEAR, divisor: YEAR, unit: 'year' },
       { ge: MONTH, divisor: MONTH, unit: 'month' },
@@ -37,7 +50,7 @@ export const fromDateTime = (date: Date) => {
   const now: number = new Date(Date.now()).getTime();
   const diff: number = now - (typeof date === 'object' ? date : new Date(date)).getTime();
   const diffAbs: number = Math.abs(diff);
-  
+
   for (const interval of intervals) {
     if (diffAbs >= interval.ge) {
         const x = Math.round(Math.abs(diff) / interval.divisor);

--- a/src/views/transaction-details/transaction-details.tsx
+++ b/src/views/transaction-details/transaction-details.tsx
@@ -9,7 +9,7 @@ import {
   AlertDescription,
   AlertIcon,
 } from "components"
-import { base64ToArrayBuffer } from "helper/convert"
+import { base64UrlToArrayBuffer } from "helper/convert"
 import {
   MultisigActions,
   SubmittedMultisigTxnDetails,
@@ -42,7 +42,7 @@ function TxnDetails() {
   const { txnId } = useParams()
 
   const txnIdBytes = txnId
-    ? base64ToArrayBuffer(decodeURIComponent(txnId))
+    ? base64UrlToArrayBuffer(decodeURIComponent(txnId))
     : undefined
 
   const {


### PR DESCRIPTION
This removes the "="s at the end, which encodes to "%3D" and dont look good. This is backward compatible in case people kept URIs somewhere.

Testing were added for round trip and for golden values.

Manual testing of URIs was done with local and prod backend.